### PR TITLE
Fixed plugin dependencies

### DIFF
--- a/src/main/java/com/efnilite/skematic/Skematic.java
+++ b/src/main/java/com/efnilite/skematic/Skematic.java
@@ -14,9 +14,9 @@ public class Skematic extends JavaPlugin {
     @Override
     public void onEnable() {
 
-        if (getServer().getPluginManager().getPlugin("Skript") == null || getServer().getPluginManager().getPlugin("FastAsyncWorldEdit") == null) {
+        if (getServer().getPluginManager().getPlugin("FastAsyncWorldEdit") == null) {
 
-            getLogger().warning("You need Skript and FastAsyncWorldEdit for Skematic to work! Disabling..");
+            getLogger().severe("You need FastAsyncWorldEdit for Skematic to work! Disabling..");
 
             getServer().getPluginManager().disablePlugin(this);
             return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,3 +5,5 @@ author: Efnilite
 main: com.efnilite.skematic.Skematic
 api-version: 1.13
 website: https://forums.skunity.com/resources/skematic.671/
+depend: Skript
+softdepend: FastAsyncWorldEdit


### PR DESCRIPTION
Added FastAsyncWorldEdit to softdepend in plugin.yml so that it would be sure to be loaded before Skematic.  Also added Skript to depend, because the plugin already won't load without Skript.  Consequently, removed Skript from the startup checks.  Also changed the error message to severe rather than warning.